### PR TITLE
Custom args

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ initialization. The valid attributes for the options object are the following:
 - `sttyPath` - the path to the `stty` command (defaults to /bin/stty)
 - `initTimeout` - maximum initialization duration (defaults to 10 seconds);
 	set to `null` to allow an infinite amount of time
+- customArgs - an array of additional arguments to pass to the `stty` command
 
 ### `port.initialize([cb])`
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ initialization. The valid attributes for the options object are the following:
 - `sttyPath` - the path to the `stty` command (defaults to /bin/stty)
 - `initTimeout` - maximum initialization duration (defaults to 10 seconds);
 	set to `null` to allow an infinite amount of time
-- `customArgs` - an array of additional arguments to pass to the `stty` command
+- `sttyArgs` - an array of additional arguments to pass to the `stty` command
 
 ### `port.initialize([cb])`
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ initialization. The valid attributes for the options object are the following:
 - `sttyPath` - the path to the `stty` command (defaults to /bin/stty)
 - `initTimeout` - maximum initialization duration (defaults to 10 seconds);
 	set to `null` to allow an infinite amount of time
-- customArgs - an array of additional arguments to pass to the `stty` command
+- `customArgs` - an array of additional arguments to pass to the `stty` command
 
 ### `port.initialize([cb])`
 

--- a/serialport.js
+++ b/serialport.js
@@ -22,6 +22,7 @@ initialization. The valid attributes for the options object are the following:
 - sttyPath - the path to the `stty` command (defaults to /bin/stty)
 - initTimeout - maximum initialization duration (defaults to 10 seconds);
 	set to `null` to allow an infinite amount of time
+- customArgs - an array of additional arguments to pass to the `stty` command
 */
 function SerialPort(opts) {
 	stream.Duplex.call(this, {
@@ -37,6 +38,7 @@ function SerialPort(opts) {
 		opts.initTimeout = 10000;
 	}
 	this.initTimeout = opts.initTimeout;
+  this.customArgs = opts.customArgs || [];
 	this._readStream = null;
 	this._writeStream = null;
 }
@@ -111,6 +113,12 @@ SerialPort.prototype.initialize = function(cb) {
 		default:
 			return cb(new Error("SerialPort: Invalid parity: " + self.parity) );
 	}
+  //customArgs
+  if(self.customArgs instanceof Array){
+    self.customArgs.forEach(function(arg){
+      args.push(arg);
+    });
+  }
 	//Get the file descriptors for reading/writing the SerialPort
 	fs.open(self.serialPort, "r+", function(err, readFd) {
 		if(err) {

--- a/serialport.js
+++ b/serialport.js
@@ -22,7 +22,7 @@ initialization. The valid attributes for the options object are the following:
 - sttyPath - the path to the `stty` command (defaults to /bin/stty)
 - initTimeout - maximum initialization duration (defaults to 10 seconds);
 	set to `null` to allow an infinite amount of time
-- customArgs - an array of additional arguments to pass to the `stty` command
+- sttyArgs - an array of additional arguments to pass to the `stty` command
 */
 function SerialPort(opts) {
 	stream.Duplex.call(this, {
@@ -38,7 +38,7 @@ function SerialPort(opts) {
 		opts.initTimeout = 10000;
 	}
 	this.initTimeout = opts.initTimeout;
-  this.customArgs = opts.customArgs || [];
+	this.sttyArgs = opts.sttyArgs || [];
 	this._readStream = null;
 	this._writeStream = null;
 }
@@ -113,12 +113,10 @@ SerialPort.prototype.initialize = function(cb) {
 		default:
 			return cb(new Error("SerialPort: Invalid parity: " + self.parity) );
 	}
-  //customArgs
-  if(self.customArgs instanceof Array){
-    self.customArgs.forEach(function(arg){
-      args.push(arg);
-    });
-  }
+	//sttyArgs
+	if(self.sttyArgs instanceof Array){
+		args = args.concat(self.sttyArgs);
+	}
 	//Get the file descriptors for reading/writing the SerialPort
 	fs.open(self.serialPort, "r+", function(err, readFd) {
 		if(err) {


### PR DESCRIPTION
I had a need to pass some additional arguments to the `stty` command during initialization, so I added a customArgs array to the initialization opts.
